### PR TITLE
Fixed missing variables

### DIFF
--- a/07-fundamental-python-2.Rmd
+++ b/07-fundamental-python-2.Rmd
@@ -64,10 +64,14 @@ testlist = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
 ```
 
 ```{python}
+testlist = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
 8 in testlist
 ```
 
 ```{python}
+dog_favorite_toys = {"Gibbs": "football",
+                     "Duke": "squirrel",
+                     "Barnaby": "frisbee"}
 "Gibbs" in dog_favorite_toys
 ```
 
@@ -76,6 +80,7 @@ testlist = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
 If you add `not` before `in`, you can test whether an item is not contained in some collection of items. While `7 in testlist` was False, because 7 was not in the collection of items in `testlist`, `7 not in testlist` should be True, because 7 is in fact not in the `testlist` collection.
 
 ```{python}
+testlist = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
 7 not in testlist
 ```
 
@@ -141,6 +146,9 @@ Data types and structures that are collections of items (e.g., a string which is
 
 ```{python}
 len("acgt")
+dog_favorite_toys = {"Gibbs": "football",
+                     "Duke": "squirrel",
+                     "Barnaby": "frisbee"}
 len(dog_favorite_toys)
 len([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144])
 ```

--- a/07-fundamental-python-3.Rmd
+++ b/07-fundamental-python-3.Rmd
@@ -149,6 +149,7 @@ Or it may be more complex, like seeing if the day of the week starts with the le
 
 ```{python}
 counter = 0
+dow = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 for day_of_week in dow:
     if day_of_week.startswith("T") or day_of_week.startswith("S"):
         counter = counter + 1


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?



#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).

- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/OTTR_Template/wiki/Using-Docker#adding-packages-to-the-dockerfile).

- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).

- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
